### PR TITLE
Build binary in Alpine Linux environment

### DIFF
--- a/.github/workflows/build-cmark-gfm.yml
+++ b/.github/workflows/build-cmark-gfm.yml
@@ -31,9 +31,10 @@ jobs:
       - name: Build
         if: env.VERSION != ''
         run: |
-          mkdir build && cd build && \
-          cmake .. -D CMARK_SHARED=OFF && make && \
-          cd .. && [ -f $BINARY ]
+          docker build -t build-deps - <Dockerfile.build-deps
+          docker run -it --rm -v $PWD:/app build-deps \
+            sh -c 'mkdir build && cd build && cmake .. -D CMARK_SHARED=OFF && make'
+          [ -f $BINARY ]
 
       - name: Create release
         id: create_release

--- a/Dockerfile.build-deps
+++ b/Dockerfile.build-deps
@@ -1,0 +1,4 @@
+FROM alpine:3.11
+WORKDIR /app
+RUN apk add --no-cache --virtual .build-deps \
+        build-base cmake python3 curl


### PR DESCRIPTION
This makes the resulting binary usable from inside the target environment
without the need to install glibc or switch it to Ubuntu.